### PR TITLE
docs: align index/implementation links to v4.1

### DIFF
--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -273,10 +273,16 @@ See [appendices/integration-mapping.md](../appendices/integration-mapping.md) fo
 
 ## Resources
 
-- **Main Charter**: [charter/asi-bor-v4.0.md](../charter/asi-bor-v4.0.md)
+- **Main Charter**: [charter/asi-bor-v4.1.md](../charter/asi-bor-v4.1.md)
+- **Previous Version**: [charter/asi-bor-v4.0.md](../charter/asi-bor-v4.0.md)
 - **Schemas**: [schemas/](../schemas/)
 - **Simulations**: [simulations/](../simulations/)
 - **Integration Mappings**: [appendices/integration-mapping.md](../appendices/integration-mapping.md)
+
+## Notation (Project Maintenance)
+
+- **2025-12-12**: Updated the “Main Charter” resource link to point at the current v4.1 charter while keeping
+  a direct link to v4.0 as historical reference. No normative text changed.
 
 ## Implementation of v4.1 Enhancements
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -42,7 +42,7 @@ This index helps:
 ### For Policy Makers
 
 **Charter Documents**:
-- [charter/asi-bor-v4.0.md](../charter/asi-bor-v4.0.md) - Current charter (Draft 4.0)
+- [charter/asi-bor-v4.1.md](../charter/asi-bor-v4.1.md) - Current charter (Draft 4.1)
 - [charter/asi-bor-v3.0.md](../charter/asi-bor-v3.0.md) - Previous charter (Draft 3.0)
 
 **Implementation**:
@@ -57,7 +57,7 @@ This index helps:
 ### For Developers
 
 **Schemas**:
-- [schemas/charter.v4.json](../schemas/charter.v4.json) - Current schema
+- [schemas/charter.v4.1.json](../schemas/charter.v4.1.json) - Current schema
 - [schemas/charter.v3.json](../schemas/charter.v3.json) - Previous schema
 - [schemas/schema-docs.md](../schemas/schema-docs.md) - Schema documentation
 - [schemas/SCHEMA-CHARTER-MAPPING.md](../schemas/SCHEMA-CHARTER-MAPPING.md) - Schema mapping
@@ -74,7 +74,7 @@ This index helps:
 ### For Researchers
 
 **Charter**:
-- [charter/asi-bor-v4.0.md](../charter/asi-bor-v4.0.md) - Current charter
+- [charter/asi-bor-v4.1.md](../charter/asi-bor-v4.1.md) - Current charter
 - [charter/README.md](../charter/README.md) - Charter directory
 
 **Citations**:
@@ -90,7 +90,7 @@ This index helps:
 ### Charter Content
 
 **Main Charter**:
-- [charter/asi-bor-v4.0.md](../charter/asi-bor-v4.0.md) - Draft 4.0 (current)
+- [charter/asi-bor-v4.1.md](../charter/asi-bor-v4.1.md) - Draft 4.1 (current)
 - [charter/asi-bor-v3.0.md](../charter/asi-bor-v3.0.md) - Draft 3.0 (historical)
 
 **Appendices**:
@@ -139,7 +139,7 @@ This index helps:
 - [README.md](../README.md) - Overview
 - [MISSION.md](../MISSION.md) - Mission
 - [PHILOSOPHY.md](../PHILOSOPHY.md) - Philosophy
-- [charter/asi-bor-v4.0.md](../charter/asi-bor-v4.0.md) - Charter
+- [charter/asi-bor-v4.1.md](../charter/asi-bor-v4.1.md) - Charter
 
 ### Contributing
 - [docs/CONTRIBUTING.md](CONTRIBUTING.md) - Guidelines
@@ -162,7 +162,7 @@ This index helps:
 1. [README.md](../README.md) - Start here
 2. [MISSION.md](../MISSION.md) - Project purpose
 3. [PHILOSOPHY.md](../PHILOSOPHY.md) - Collaborative philosophy
-4. [charter/asi-bor-v4.0.md](../charter/asi-bor-v4.0.md) - Main charter
+4. [charter/asi-bor-v4.1.md](../charter/asi-bor-v4.1.md) - Main charter
 
 ### For Contributors
 1. [docs/CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
@@ -171,8 +171,14 @@ This index helps:
 
 ### For Implementers
 1. [docs/IMPLEMENTATION.md](IMPLEMENTATION.md) - Implementation guide
-2. [schemas/charter.v4.json](../schemas/charter.v4.json) - Schema
+2. [schemas/charter.v4.1.json](../schemas/charter.v4.1.json) - Schema
 3. [appendices/integration-mapping.md](../appendices/integration-mapping.md) - Integration
+
+## Notation (Project Maintenance)
+
+- **2025-12-12**: Updated INDEX links that still pointed to v4.0 / `charter.v4.json` so they consistently
+  reference the current v4.1 charter + schema. This is a documentation-only consistency change (no charter
+  content altered).
 
 ## Search Index
 

--- a/docs/TERMINOLOGY.md
+++ b/docs/TERMINOLOGY.md
@@ -130,9 +130,14 @@ This guide:
 
 ## Related Files
 
-- See `/charter/asi-bor-v4.0.md` Article 0.2 for official definitions
+- See `/charter/asi-bor-v4.1.md` Article 0.2 for official definitions (current)
 - See `/docs/CROSS-REFERENCE-INDEX.md` for clause ID references
 - See `/docs/CHANGELOG.md` for terminology evolution
+
+## Notation (Project Maintenance)
+
+- **2025-12-12**: Updated the “official definitions” pointer to reference the current v4.1 charter to avoid
+  accidental drift when readers follow terminology links.
 
 ## Maintenance
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -5,8 +5,14 @@ This directory contains machine-readable JSON schemas for the ASI Bill of Rights
 ## Contents
 
 - `charter.v3.json` - Machine-readable schema for Draft 3.0
-- `charter.v4.json` - Machine-readable schema for Draft 4.0
+- `charter.v4.1.json` - Machine-readable schema for Draft 4.1 (current)
+- `charter.v4.json` - Machine-readable schema for Draft 4.0 (historical reference)
 - `schema-docs.md` - Documentation explaining schema structure and usage
+
+## Notation (Project Maintenance)
+
+- **2025-12-12**: Updated the “Contents” list so the current schema is correctly identified as v4.1,
+  matching `README.md` and `charter/asi-bor-v4.1.md`.
 
 ## Purpose
 


### PR DESCRIPTION
## Summary
- Fixes remaining documentation drift where `docs/INDEX.md`, `docs/IMPLEMENTATION.md`, `docs/TERMINOLOGY.md`, and `schemas/README.md` still pointed to v4.0 / `charter.v4.json`.
- Adds small maintenance notation blocks documenting why the links were updated.

## Test plan
- [ ] Open `docs/INDEX.md` and verify “Current charter”/“Current schema” links resolve to v4.1
- [ ] Spot-check links in GitHub preview